### PR TITLE
Task 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # automation_course_assignment
+
+Task 2: Writing A Bash Script 
+
+Once the virtual machine (VM) is set up, the next steps encompasses writing a script to configure the Virtual Machine for hosting a web server and later automating some maintainance tasks. Let's take a look at each of these sub tasks one at a time. 
+
+ 
+
+Hosting Web Server: The first step is to set up a web server on the EC2 instance for hosting a website. It is also important to ensure that the apache2 server is running and it restarts automatically in case the EC2 instance reboots.
+
+ 
+
+Archiving Logs: Daily requests to web servers generate lots of access logs. These log files  serve as an  important tool for troubleshooting.  However, these logs can also result in the servers running out of disk space and can make them stop working. To avoid this, one of the best practices is to create a backup of these logs by compressing the logs directory and archiving it to the s3 bucket (Storage). 
+
+ 
+
+All this becomes a weekly/daily activity. These tasks can take a long time if done manually again and again. You have been assigned to write an automation bash script named ‘automation. sh’ to automate all these workflows.

--- a/automation.sh
+++ b/automation.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+user_name="gemhar"
+s3_bucket="upgrad-gemhar"
+
+sudo apt update -y
+isApacheInstalled=$(dpkg --get-selections | grep apache2| awk '{print $1}')
+if [[ "$isApacheInstalled" =~ .*"apache2".* ]]; then
+  echo "Apache Server installed...";
+else
+        echo "Installing apache 2..."
+        apt-get install apache2 -y
+fi
+
+apacheServerConfig=$(systemctl list-unit-files | grep apache2.service | awk '{print $2}')
+if [[ $apacheServerConfig = "enabled" ]];then
+        echo "Service already configured..."
+else
+        systemctl start apache2.service
+        echo "Service already enabled..."
+fi
+ServiceStatus="$(systemctl is-active apache2.service)"
+if [ "${ServiceStatus}" != "active" ]; then
+        sudo systemctl start apache2.service
+fi
+timestamp=$(date '+%d%m%Y-%H%M%S')
+
+
+cd /var/log/apache2/
+fileName=$user_name"-httpd-logs-"$timestamp
+tar -cf ${fileName}.tar *.log
+aws s3 cp ${fileName}.tar s3://${s3_bucket}/${fileName}.tar


### PR DESCRIPTION
-     Perform an update of the package details and the package list at the start of the script.
-      
-     Install the apache2 package if it is not already installed. (The dpkg and apt commands are used to check the installation of the packages.)
-     Ensure that the apache2 service is running. 
-     Ensure that the apache2 service is enabled. (The systemctl or service commands are used to check if the services are enabled and running. Enabling apache2 as a service ensures that it runs as soon as our machine reboots. It is a daemon process that runs in the background.)
-     Create a tar archive of apache2 access logs and error logs that are present in the /var/log/apache2/ directory and place the tar into the /tmp/ directory. Create a tar of only the .log files (for example access.log) and not any other file type (For example: .zip and .tar) that are already present in the /var/log/apache2/ directory. The name of tar archive should have following format:  <your _name>-httpd-logs-<timestamp>.tar. For example: Ritik-httpd-logs-01212021-101010.tar                                                             Hint : use timestamp=$(date '+%d%m%Y-%H%M%S') )
-     The script should run the AWS CLI command and copy the archive to the s3 bucket. 